### PR TITLE
Reset sync attributes when not syncing

### DIFF
--- a/custom_components/mdadm_state/binary_sensor.py
+++ b/custom_components/mdadm_state/binary_sensor.py
@@ -81,3 +81,8 @@ class mdadm(Entity):
             self._resync_progress = device_config.resync.progress
             self._resync_finish = device_config.resync.finish
             self._resync_speed = device_config.resync.speed
+        else:
+            self._resync_operation = None
+            self._resync_progress = None
+            self._resync_finish = None
+            self._resync_speed = None


### PR DESCRIPTION
Extra attributes about syncing were never reset after the sync is completed 